### PR TITLE
fix: remove aic8800 udev rule

### DIFF
--- a/debian/radxa-udev.radxa-aic8800.udev
+++ b/debian/radxa-udev.radxa-aic8800.udev
@@ -1,1 +1,0 @@
-SUBSYSTEM=="net", ACTION=="add", ATTR{address}=="88:00:*", NAME="$env{ID_NET_SLOT}"

--- a/debian/rules
+++ b/debian/rules
@@ -13,4 +13,3 @@ override_dh_installudev:
 	dh_installudev -pradxa-udev --name=radxa-gpiod --priority=99
 	dh_installudev -pradxa-udev --name=radxa-spidev --priority=99
 	dh_installudev -pradxa-udev --name=radxa-pwm --priority=99
-	dh_installudev -pradxa-udev --name=radxa-aic8800 --priority=99


### PR DESCRIPTION
To keep AIC8800 interface name